### PR TITLE
Add glow effect, and fixes

### DIFF
--- a/src/lib/components/Rect.svelte
+++ b/src/lib/components/Rect.svelte
@@ -8,6 +8,7 @@
     getHoverColor,
     formatTeacherList,
   } from "$lib/helper";
+  import { glow } from "$lib/stores";
   import { onMount } from "svelte";
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
@@ -44,6 +45,7 @@
   let tooltipWidth: number;
   let tooltipTop = h + 15; // the offset from the top of the room in px
   let tooltipLeft: number;
+
   onMount(() => {
     tooltipLeft = (w - tooltipWidth) / 2; // the offset from the left to make tooltip centered
   });
@@ -52,9 +54,8 @@
 <div>
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
-    id="tooltip-target"
-    class="absolute flex cursor-default flex-col justify-center rounded-md border border-none p-1 text-center transition ease-in hover:-translate-x-1 hover:-translate-y-1 hover:scale-105"
-    style="left: {x}px; top: {y}px; width: {w}px; height: {h}px; background-color: {normalColor};"
+    class="tooltip-target absolute flex cursor-default flex-col justify-center rounded-md border border-none p-1 text-center transition ease-in hover:-translate-x-1 hover:-translate-y-1 hover:scale-105"
+    style="left: {x}px; top: {y}px; width: {w}px; height: {h}px; background-color: {normalColor};{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }"
     on:mouseover={(e) => (e.currentTarget.style.backgroundColor = hoverColor)}
     on:mouseleave={(e) => (e.currentTarget.style.backgroundColor = normalColor)}
     on:focus>
@@ -62,8 +63,7 @@
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {y + tooltipTop}px; left: {x + tooltipLeft}px;">
     <h3>#️⃣ {tooltipRoomText}</h3>
@@ -82,23 +82,11 @@
 </div>
 
 <style>
-  #tooltip-target {
+  .tooltip-target {
     @apply z-0;
   }
 
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-10 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-  #tooltip-target:hover ~ #tooltip {
+  .tooltip-target:hover + .tooltip {
     @apply visible;
   }
 </style>

--- a/src/lib/components/svgs/Balcony.svelte
+++ b/src/lib/components/svgs/Balcony.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 808,
     y = 763,
@@ -50,7 +51,7 @@
 <div
   class="absolute inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
       width={w}
@@ -108,8 +109,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -128,30 +128,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible bg-black text-center text-white;
-    @apply absolute z-20 whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/CCC.svelte
+++ b/src/lib/components/svgs/CCC.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 850,
     y = 763,
@@ -50,10 +51,10 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
-      style="width: {w};"
+      width={w}
       viewBox="0 0 278 256"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
@@ -96,8 +97,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -116,30 +116,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-10 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/CafeteriaF1.svelte
+++ b/src/lib/components/svgs/CafeteriaF1.svelte
@@ -12,6 +12,7 @@
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
   import Rect from "../Rect.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 592,
     y = 815,
@@ -51,10 +52,10 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
-      style="width: {w};"
+      width={w}
       viewBox="0 0 450 720"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
@@ -102,8 +103,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -125,30 +125,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
 
 <Rect id="brr_cafeteria" x={572} y={827} w={25} h={25} />
 <Rect id="grr_cafeteria" x={601} y={827} w={25} h={25} />
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-10 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/CafeteriaF2.svelte
+++ b/src/lib/components/svgs/CafeteriaF2.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 592,
     y = 830,
@@ -50,7 +51,7 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
       width={w}
@@ -103,8 +104,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -123,30 +123,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-10 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/Gym.svelte
+++ b/src/lib/components/svgs/Gym.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 945,
     y = 730,
@@ -50,10 +51,10 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
-      style="width: {w};"
+      width={w}
       viewBox="0 0 505 774"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
@@ -100,8 +101,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -120,30 +120,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-20 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/Library.svelte
+++ b/src/lib/components/svgs/Library.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 592,
     y = 913,
@@ -50,7 +51,7 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
       width={w}
@@ -111,8 +112,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -131,30 +131,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-10 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/MainOffice.svelte
+++ b/src/lib/components/svgs/MainOffice.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 812,
     y = 850,
@@ -50,10 +51,10 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
-      style="width: {w};"
+      width={w}
       viewBox="0 0 425 545"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
@@ -121,8 +122,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -141,30 +141,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-20 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/components/svgs/Theater.svelte
+++ b/src/lib/components/svgs/Theater.svelte
@@ -11,6 +11,7 @@
   import RoomTypePill from "$lib/components/RoomTypePill.svelte";
   import { RoomType } from "$lib/types";
   import SubjectPill from "$lib/components/SubjectPill.svelte";
+  import { glow } from "$lib/stores";
 
   let x = 470,
     y = 860,
@@ -40,6 +41,7 @@
   let tooltipLeft: number;
   onMount(() => {
     tooltipLeft = (w - tooltipWidth) / 2; // the offset from the left to make tooltip centered
+    console.log(tooltipLeft, w, tooltipWidth);
   });
 
   let translateValue = 0;
@@ -50,10 +52,10 @@
 <div
   class="absolute z-0 inline-block text-center transition"
   style="left: {x}px; top: {y}px; 
-transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);">
+transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%, {scaleValue}%);{ $glow.includes(id) ? " box-shadow: 8px 8px 20px yellow, -8px 8px 20px yellow, 8px -8px 20px yellow, -8px -8px 20px yellow; z-index: 1;" : "" }">
   <div>
     <svg
-      style="width: {w};"
+      width={w}
       viewBox="0 0 402 611"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
@@ -100,8 +102,7 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
   </div>
 
   <div
-    id="tooltip"
-    class="pointer-events-none"
+    class="tooltip pointer-events-none"
     bind:clientWidth={tooltipWidth}
     style="top: {tooltipTop}px; left: {tooltipLeft}px; visibility: {isHovering
       ? 'visible'
@@ -120,30 +121,3 @@ transform: translate({translateValue}px, {translateValue}px) scale({scaleValue}%
     </div>
   </div>
 </div>
-
-<style>
-  svg {
-    @apply fill-none;
-  }
-
-  .svg {
-    @apply border-none stroke-none stroke-0;
-  }
-
-  .svg:hover {
-    @apply stroke-none transition duration-200 ease-in-out;
-  }
-
-  #tooltip::before {
-    content: "";
-    transform: translate(-50%, -100%);
-    @apply absolute left-1/2 top-0 block w-0;
-    @apply border-8 border-transparent border-b-black;
-  }
-
-  #tooltip {
-    @apply invisible z-10 bg-black text-center text-white;
-    @apply absolute whitespace-nowrap;
-    @apply rounded-md px-3 py-3;
-  }
-</style>

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -103,3 +103,5 @@ export const formatTeacherList = (teacherArr: string[] | undefined) => {
 
 // object to map function to make my life easier
 export const o2m = (o: Bldg): Map<ID, Room> => new Map(Object.entries(o));
+
+export const isSecondFloor = (id: ID): boolean => id.startsWith("62") || id.startsWith("72") || ["balcony", "1214", "1215", "library", "mezzanine"].includes(id);

--- a/src/lib/rooms.css
+++ b/src/lib/rooms.css
@@ -1,0 +1,24 @@
+.tooltip::before {
+  content: "";
+  transform: translate(-50%, -100%);
+  @apply absolute left-1/2 top-0 block w-0;
+  @apply border-8 border-transparent border-b-black;
+}
+
+.tooltip {
+  @apply invisible bg-black text-center text-white;
+  @apply absolute z-20 whitespace-nowrap;
+  @apply rounded-md px-3 py-3;
+}
+
+svg {
+  @apply fill-none;
+}
+
+.svg {
+  @apply border-none stroke-none stroke-0;
+}
+
+.svg:hover {
+  @apply stroke-none transition duration-200 ease-in-out;
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -2,3 +2,4 @@ import { writable } from "svelte/store";
 
 export const isSecondFloorVisible = writable(false);
 export const windowWidth = writable(1000);
+export const glow = writable([""]); //I can't really get it to work with `writable(undefined)`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 import type { Moment } from "moment";
 
 export type ID = string;
+export type Club = string;
 export enum RoomType {
   ClassRoom,
   AdminRoom,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import data from "$lib/data";
+  import "$lib/rooms.css";
+  import { isSecondFloor } from "$lib/helper";
+
   import FloorToggle from "$lib/components/FloorToggle.svelte";
   import Header from "$lib/components/Header.svelte";
 
@@ -20,12 +24,25 @@
   import WagonWheel from "$lib/components/bldgs/WagonWheel.svelte";
   import BldgPhysEd from "$lib/components/bldgs/BldgPhysEd.svelte";
   import CafeteriaF2 from "$lib/components/svgs/CafeteriaF2.svelte";
-  import { isSecondFloorVisible } from "$lib/stores";
+  import { isSecondFloorVisible, glow } from "$lib/stores";
   import Balcony from "$lib/components/svgs/Balcony.svelte";
   import Library from "$lib/components/svgs/Library.svelte";
   import BldgMain from "$lib/components/bldgs/BldgMain.svelte";
   import Roads from "$lib/components/Roads.svelte";
   import BldgSix from "$lib/components/bldgs/BldgSix.svelte";
+
+  import { onMount } from "svelte";
+
+  onMount(() => {
+    let rooms = (new URLSearchParams(window.location.search)).get("rooms")?.toLowerCase();
+    //if some rooms are on first floor (and are hidden in second floor mode), others on second, second floor one will show first, toggle can be used to show the glowing rooms on first floor
+    if (rooms) {
+      $glow = rooms.split(",");
+      if ($glow.some(isSecondFloor)) {
+        $isSecondFloorVisible = true;
+      }
+    }
+  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This PR adds a query param that will make rooms glow:
- http://localhost:5173/?rooms=cafeteria,main_office,6126,504,7203
- http://localhost:5173/?rooms=215

It also includes a fix that allows some SVGs that were previously not displayed on firefox to be displayed.

Additionally, chunks of duplicated css were removed and put into one file. Also, `#tooltip` and `#tooltip-target` were changed to  `.tooltip` and `.tooltip-target`, since IDs should be unique!!